### PR TITLE
Fix FOUC issues with iframe visibility and loading overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,11 +50,26 @@
 
     <link
       rel="preload"
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined&display=block"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined&display=swap"
       as="style"
-      onload="this.onload=null;this.rel='stylesheet';document.documentElement.classList.add('icons-loaded')"
+      id="icon-font-link"
       onerror="console.error('Failed to load Material Symbols icon font');document.documentElement.classList.add('icons-loaded')"
     />
+    <script>
+      (function() {
+        var link = document.getElementById('icon-font-link');
+        link.onload = function() {
+          link.onload = null;
+          link.rel = 'stylesheet';
+          var fontsReady = document.fonts
+            ? document.fonts.load('1em "Material Symbols Outlined"')
+            : Promise.resolve();
+          Promise.race([fontsReady, new Promise(function(r) { setTimeout(r, 3000); })])
+            .then(function() { document.documentElement.classList.add('icons-loaded'); })
+            .catch(function() { document.documentElement.classList.add('icons-loaded'); });
+        };
+      })();
+    </script>
 
     <link
       rel="stylesheet"
@@ -95,6 +110,9 @@
       /* Hide icon font text until Material Symbols loads */
       .material-symbols-outlined {
         visibility: hidden;
+        display: inline-block;
+        width: 1em;
+        overflow: hidden;
       }
       .icons-loaded .material-symbols-outlined {
         visibility: visible;

--- a/index.html
+++ b/index.html
@@ -68,12 +68,10 @@
           var fontsReady = document.fonts
             ? document.fonts.load('1em "Material Symbols Outlined"')
             : Promise.resolve();
-          Promise.race([fontsReady, new Promise(function(r) { setTimeout(function() { console.warn('Icon font load timed out after 3s'); r(); }, 3000); })])
+          Promise.race([fontsReady, new Promise(function(r) { setTimeout(function() { window.__iconFontFailed = true; console.warn('Icon font load timed out after 3s'); r(); }, 3000); })])
             .catch(function(err) { window.__iconFontFailed = true; console.warn('Icon font loading issue:', err); })
             .finally(function() { document.documentElement.classList.add('icons-loaded'); });
         };
-        // Handle already-loaded case (cached or fast network)
-        if (link.sheet) { link.onload(); }
       })();
     </script>
 

--- a/index.html
+++ b/index.html
@@ -68,10 +68,12 @@
           var fontsReady = document.fonts
             ? document.fonts.load('1em "Material Symbols Outlined"')
             : Promise.resolve();
-          Promise.race([fontsReady, new Promise(function(r) { setTimeout(r, 3000); })])
-            .catch(function(err) { console.warn('Icon font loading issue:', err); })
+          Promise.race([fontsReady, new Promise(function(r) { setTimeout(function() { console.warn('Icon font load timed out after 3s'); r(); }, 3000); })])
+            .catch(function(err) { window.__iconFontFailed = true; console.warn('Icon font loading issue:', err); })
             .finally(function() { document.documentElement.classList.add('icons-loaded'); });
         };
+        // Handle already-loaded case (cached or fast network)
+        if (link.sheet) { link.onload(); }
       })();
     </script>
 

--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined&display=block"
       as="style"
       onload="this.onload=null;this.rel='stylesheet';document.documentElement.classList.add('icons-loaded')"
+      onerror="document.documentElement.classList.add('icons-loaded')"
     />
 
     <link
@@ -94,10 +95,6 @@
       /* Hide icon font text until Material Symbols loads */
       .material-symbols-outlined {
         visibility: hidden;
-        display: inline-block;
-        width: 1em;
-        height: 1em;
-        overflow: hidden;
       }
       .icons-loaded .material-symbols-outlined {
         visibility: visible;

--- a/index.html
+++ b/index.html
@@ -49,10 +49,11 @@
     />
 
     <link
-      rel="preload"
+      rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined&display=swap"
-      as="style"
+      media="print"
       id="icon-font-link"
+      onload="this.media='all'"
       onerror="window.__iconFontFailed=true;console.error('Failed to load Material Symbols icon font');document.documentElement.classList.add('icons-loaded')"
     />
     <script>
@@ -62,9 +63,10 @@
           document.documentElement.classList.add('icons-loaded');
           return;
         }
+        var origOnload = link.onload;
         link.onload = function() {
+          if (origOnload) origOnload.call(this);
           link.onload = null;
-          link.rel = 'stylesheet';
           var fontsReady = document.fonts
             ? document.fonts.load('1em "Material Symbols Outlined"')
             : Promise.resolve();

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
 
     <link
       rel="preload"
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined&display=block"
       as="style"
       onload="this.onload=null;this.rel='stylesheet'"
     />

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined&display=block"
       as="style"
       onload="this.onload=null;this.rel='stylesheet';document.documentElement.classList.add('icons-loaded')"
-      onerror="document.documentElement.classList.add('icons-loaded')"
+      onerror="console.error('Failed to load Material Symbols icon font');document.documentElement.classList.add('icons-loaded')"
     />
 
     <link

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
       media="print"
       id="icon-font-link"
       onload="this.media='all'"
-      onerror="window.__iconFontFailed=true;console.error('Failed to load Material Symbols icon font');document.documentElement.classList.add('icons-loaded')"
+      onerror="window.__iconFontFailed=true;window.dispatchEvent(new Event('icon-font-failed'));console.error('Failed to load Material Symbols icon font');document.documentElement.classList.add('icons-loaded')"
     />
     <script>
       (function() {
@@ -63,17 +63,43 @@
           document.documentElement.classList.add('icons-loaded');
           return;
         }
+        var timeoutId;
+        function waitForFont() {
+          var fontsReady = document.fonts
+            ? document.fonts.load('1em "Material Symbols Outlined"')
+            : Promise.resolve();
+          timeoutId = setTimeout(function() {
+            timeoutId = null;
+            window.__iconFontFailed = true;
+            window.dispatchEvent(new Event('icon-font-failed'));
+            console.warn('Icon font load timed out after 3s');
+          }, 3000);
+          fontsReady
+            .then(function() {
+              if (timeoutId != null) { clearTimeout(timeoutId); timeoutId = null; }
+            })
+            .catch(function(err) {
+              if (timeoutId != null) { clearTimeout(timeoutId); timeoutId = null; }
+              window.__iconFontFailed = true;
+              window.dispatchEvent(new Event('icon-font-failed'));
+              console.warn('Icon font loading issue:', err);
+            })
+            .finally(function() {
+              document.documentElement.classList.add('icons-loaded');
+            });
+        }
         var origOnload = link.onload;
         link.onload = function() {
           if (origOnload) origOnload.call(this);
           link.onload = null;
-          var fontsReady = document.fonts
-            ? document.fonts.load('1em "Material Symbols Outlined"')
-            : Promise.resolve();
-          Promise.race([fontsReady, new Promise(function(r) { setTimeout(function() { window.__iconFontFailed = true; console.warn('Icon font load timed out after 3s'); r(); }, 3000); })])
-            .catch(function(err) { window.__iconFontFailed = true; console.warn('Icon font loading issue:', err); })
-            .finally(function() { document.documentElement.classList.add('icons-loaded'); });
+          waitForFont();
         };
+        // If stylesheet already loaded (warm cache), onload already fired
+        // and media was swapped to 'all'. Run font detection directly.
+        if (link.media === 'all') {
+          link.onload = null;
+          waitForFont();
+        }
       })();
     </script>
 

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
       rel="preload"
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined&display=block"
       as="style"
-      onload="this.onload=null;this.rel='stylesheet'"
+      onload="this.onload=null;this.rel='stylesheet';document.documentElement.classList.add('icons-loaded')"
     />
 
     <link
@@ -89,6 +89,18 @@
         .virus-thumbnail-item {
           border-width: 3px !important;
         }
+      }
+
+      /* Hide icon font text until Material Symbols loads */
+      .material-symbols-outlined {
+        visibility: hidden;
+        display: inline-block;
+        width: 1em;
+        height: 1em;
+        overflow: hidden;
+      }
+      .icons-loaded .material-symbols-outlined {
+        visibility: visible;
       }
     </style>
   </head>

--- a/index.html
+++ b/index.html
@@ -53,11 +53,15 @@
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined&display=swap"
       as="style"
       id="icon-font-link"
-      onerror="console.error('Failed to load Material Symbols icon font');document.documentElement.classList.add('icons-loaded')"
+      onerror="window.__iconFontFailed=true;console.error('Failed to load Material Symbols icon font');document.documentElement.classList.add('icons-loaded')"
     />
     <script>
       (function() {
         var link = document.getElementById('icon-font-link');
+        if (!link) {
+          document.documentElement.classList.add('icons-loaded');
+          return;
+        }
         link.onload = function() {
           link.onload = null;
           link.rel = 'stylesheet';
@@ -65,8 +69,8 @@
             ? document.fonts.load('1em "Material Symbols Outlined"')
             : Promise.resolve();
           Promise.race([fontsReady, new Promise(function(r) { setTimeout(r, 3000); })])
-            .then(function() { document.documentElement.classList.add('icons-loaded'); })
-            .catch(function() { document.documentElement.classList.add('icons-loaded'); });
+            .catch(function(err) { console.warn('Icon font loading issue:', err); })
+            .finally(function() { document.documentElement.classList.add('icons-loaded'); });
         };
       })();
     </script>

--- a/main.ts
+++ b/main.ts
@@ -82,6 +82,7 @@ class VirusLoader {
     document.querySelector('#source-code a');
   virusLab: VirusLab | null = null;
   isNavigating = false;
+  private _loadGeneration = 0;
 
   constructor() {
     this.iframe = document.getElementById('container') as HTMLIFrameElement;
@@ -136,6 +137,7 @@ class VirusLoader {
   }
 
   loadVirus(name: string) {
+    const generation = ++this._loadGeneration;
     virusHasKeyboardControl = false;
 
     // Randomly choose the loading animation for each load
@@ -163,6 +165,7 @@ class VirusLoader {
     this.removeMixContainer();
 
     const safetyTimeout = setTimeout(() => {
+      if (generation !== this._loadGeneration) return;
       const msg = `Safety timeout: forcing loading animation to stop for virus: ${name}`;
       console.warn(msg);
       Sentry.captureMessage(msg, 'warning');
@@ -198,6 +201,7 @@ class VirusLoader {
           mixFrame.addEventListener(
             'load',
             () => {
+              if (generation !== this._loadGeneration) return;
               clearTimeout(safetyTimeout);
               this._delayedIframeLoaded();
             },
@@ -207,6 +211,7 @@ class VirusLoader {
           mixFrame.addEventListener(
             'error',
             () => {
+              if (generation !== this._loadGeneration) return;
               const errorMsg = `Failed to load mixed virus iframe: ${name}`;
               console.error(errorMsg);
               Sentry.captureMessage(errorMsg, 'error');
@@ -223,11 +228,25 @@ class VirusLoader {
             this.sourceCodeLink.href = this.sourceCodeUrl(name);
         } else {
           console.error('Mix not found for ID:', name);
+          Sentry.captureMessage(`Mix not found for ID: ${name}`, 'error');
           this.iframe.src = `/viruses/${playlist.viruses[0]}/`;
           this.iframe.style.display = 'block';
           this.iframe.addEventListener(
             'load',
             () => {
+              if (generation !== this._loadGeneration) return;
+              clearTimeout(safetyTimeout);
+              this._delayedIframeLoaded();
+            },
+            { once: true }
+          );
+          this.iframe.addEventListener(
+            'error',
+            () => {
+              if (generation !== this._loadGeneration) return;
+              const errorMsg = `Failed to load virus iframe: ${name}`;
+              console.error(errorMsg);
+              Sentry.captureMessage(errorMsg, 'error');
               clearTimeout(safetyTimeout);
               this._delayedIframeLoaded();
             },
@@ -240,6 +259,19 @@ class VirusLoader {
         this.iframe.addEventListener(
           'load',
           () => {
+            if (generation !== this._loadGeneration) return;
+            clearTimeout(safetyTimeout);
+            this._delayedIframeLoaded();
+          },
+          { once: true }
+        );
+        this.iframe.addEventListener(
+          'error',
+          () => {
+            if (generation !== this._loadGeneration) return;
+            const errorMsg = `Failed to load virus iframe: ${name}`;
+            console.error(errorMsg);
+            Sentry.captureMessage(errorMsg, 'error');
             clearTimeout(safetyTimeout);
             this._delayedIframeLoaded();
           },
@@ -254,6 +286,19 @@ class VirusLoader {
       this.iframe.addEventListener(
         'load',
         () => {
+          if (generation !== this._loadGeneration) return;
+          clearTimeout(safetyTimeout);
+          this._delayedIframeLoaded();
+        },
+        { once: true }
+      );
+      this.iframe.addEventListener(
+        'error',
+        () => {
+          if (generation !== this._loadGeneration) return;
+          const errorMsg = `Failed to load fallback virus iframe: ${playlist.viruses[0]}`;
+          console.error(errorMsg);
+          Sentry.captureMessage(errorMsg, 'error');
           clearTimeout(safetyTimeout);
           this._delayedIframeLoaded();
         },

--- a/main.ts
+++ b/main.ts
@@ -154,6 +154,7 @@ class VirusLoader {
     this.loadingAnimStartTime = Date.now();
     this.hideSourceCodeLink();
     this.loadingRing.classList.add('loading');
+    this.iframe.style.visibility = 'hidden';
 
     const reloadBtn = document.getElementById('reload');
     if (reloadBtn) reloadBtn.classList.add('spinning');
@@ -192,16 +193,26 @@ class VirusLoader {
           mixFrame.style.visibility = 'hidden';
           mixFrame.src = `/viruses/lab/?primary=${mix.primary}&secondary=${mix.secondary}&ratio=${mix.mixRatio}`;
 
-          mixFrame.addEventListener('load', () => {
-            clearTimeout(safetyTimeout);
-            this._delayedIframeLoaded();
-          });
+          mixFrame.addEventListener(
+            'load',
+            () => {
+              clearTimeout(safetyTimeout);
+              this._delayedIframeLoaded();
+            },
+            { once: true }
+          );
 
-          mixFrame.addEventListener('error', () => {
-            console.error('Failed to load mixed virus iframe:', name);
-            clearTimeout(safetyTimeout);
-            this._delayedIframeLoaded();
-          });
+          mixFrame.addEventListener(
+            'error',
+            () => {
+              const errorMsg = `Failed to load mixed virus iframe: ${name}`;
+              console.error(errorMsg);
+              Sentry.captureMessage(errorMsg, 'error');
+              clearTimeout(safetyTimeout);
+              this._delayedIframeLoaded();
+            },
+            { once: true }
+          );
 
           mixContainer.appendChild(mixFrame);
           document.body.appendChild(mixContainer);
@@ -212,7 +223,6 @@ class VirusLoader {
           console.error('Mix not found for ID:', name);
           this.iframe.src = `/viruses/${playlist.viruses[0]}/`;
           this.iframe.style.display = 'block';
-          this.iframe.style.visibility = 'hidden';
           this.iframe.addEventListener(
             'load',
             () => {
@@ -225,7 +235,6 @@ class VirusLoader {
       } else {
         this.iframe.src = `/viruses/${name}/`;
         this.iframe.style.display = 'block';
-        this.iframe.style.visibility = 'hidden';
         this.iframe.addEventListener(
           'load',
           () => {
@@ -240,7 +249,6 @@ class VirusLoader {
       Sentry.captureException(error);
       this.iframe.src = `/viruses/${playlist.viruses[0]}/`;
       this.iframe.style.display = 'block';
-      this.iframe.style.visibility = 'hidden';
       this.iframe.addEventListener(
         'load',
         () => {
@@ -263,7 +271,12 @@ class VirusLoader {
   }
 
   iframeLoaded() {
-    this.loadingAnim.stop();
+    try {
+      this.loadingAnim.stop();
+    } catch (error) {
+      console.error('Failed to stop loading animation:', error);
+      Sentry.captureException(error);
+    }
     document.querySelectorAll('.tv-static-canvas').forEach(el => {
       (el as HTMLElement).style.pointerEvents = 'none';
       el.parentNode?.removeChild(el);

--- a/main.ts
+++ b/main.ts
@@ -16,6 +16,7 @@ import { toggleInfo, hideInfo, teleportMenu, shuffleTitle } from './ui/menu';
 declare global {
   interface Window {
     TVStaticLoading?: typeof TVStaticLoading;
+    __iconFontFailed?: boolean;
   }
 }
 
@@ -30,6 +31,13 @@ if (import.meta.env.PROD) {
     tracesSampleRate: 1.0,
     profilesSampleRate: 1.0,
   });
+
+  if (window.__iconFontFailed) {
+    Sentry.captureMessage(
+      'Material Symbols icon font failed to load',
+      'warning'
+    );
+  }
 }
 
 console.log(
@@ -82,8 +90,17 @@ class VirusLoader {
     document.querySelector('#source-code a');
   virusLab: VirusLab | null = null;
   isNavigating = false;
+  /**
+   * Generation counter for cancelling stale iframe loads.
+   * Each loadVirus() call increments this and captures the value locally.
+   * All async callbacks (load, error, safety timeout, reveal delay) compare
+   * their captured generation against the current value and bail out if a
+   * newer load has superseded them.
+   */
   private _loadGeneration = 0;
+  /** Pending setTimeout ID for the minimum-animation-duration delay before revealing the iframe. */
   private _pendingRevealTimeout: ReturnType<typeof setTimeout> | null = null;
+  private _safetyTimeout: ReturnType<typeof setTimeout> | null = null;
 
   constructor() {
     this.iframe = document.getElementById('container') as HTMLIFrameElement;
@@ -145,6 +162,11 @@ class VirusLoader {
       this._pendingRevealTimeout = null;
     }
 
+    if (this._safetyTimeout !== null) {
+      clearTimeout(this._safetyTimeout);
+      this._safetyTimeout = null;
+    }
+
     virusHasKeyboardControl = false;
 
     // Randomly choose the loading animation for each load
@@ -171,7 +193,7 @@ class VirusLoader {
     // Clean up any existing mixed virus
     this.removeMixContainer();
 
-    const safetyTimeout = setTimeout(() => {
+    this._safetyTimeout = setTimeout(() => {
       if (generation !== this._loadGeneration) return;
       const msg = `Safety timeout: forcing loading animation to stop for virus: ${name}`;
       console.warn(msg);
@@ -205,27 +227,10 @@ class VirusLoader {
           mixFrame.style.visibility = 'hidden';
           mixFrame.src = `/viruses/lab/?primary=${mix.primary}&secondary=${mix.secondary}&ratio=${mix.mixRatio}`;
 
-          mixFrame.addEventListener(
-            'load',
-            () => {
-              if (generation !== this._loadGeneration) return;
-              clearTimeout(safetyTimeout);
-              this._delayedIframeLoaded(generation);
-            },
-            { once: true }
-          );
-
-          mixFrame.addEventListener(
-            'error',
-            () => {
-              if (generation !== this._loadGeneration) return;
-              const errorMsg = `Failed to load mixed virus iframe: ${name}`;
-              console.error(errorMsg);
-              Sentry.captureMessage(errorMsg, 'error');
-              clearTimeout(safetyTimeout);
-              this._delayedIframeLoaded(generation);
-            },
-            { once: true }
+          this._attachIframeListeners(
+            mixFrame,
+            generation,
+            `mixed virus iframe: ${name}`
           );
 
           mixContainer.appendChild(mixFrame);
@@ -238,51 +243,19 @@ class VirusLoader {
           Sentry.captureMessage(`Mix not found for ID: ${name}`, 'error');
           this.iframe.src = `/viruses/${playlist.viruses[0]}/`;
           this.iframe.style.display = 'block';
-          this.iframe.addEventListener(
-            'load',
-            () => {
-              if (generation !== this._loadGeneration) return;
-              clearTimeout(safetyTimeout);
-              this._delayedIframeLoaded(generation);
-            },
-            { once: true }
-          );
-          this.iframe.addEventListener(
-            'error',
-            () => {
-              if (generation !== this._loadGeneration) return;
-              const errorMsg = `Failed to load virus iframe: ${name}`;
-              console.error(errorMsg);
-              Sentry.captureMessage(errorMsg, 'error');
-              clearTimeout(safetyTimeout);
-              this._delayedIframeLoaded(generation);
-            },
-            { once: true }
+          this._attachIframeListeners(
+            this.iframe,
+            generation,
+            `fallback virus iframe (${playlist.viruses[0]}) after mix not found: ${name}`
           );
         }
       } else {
         this.iframe.src = `/viruses/${name}/`;
         this.iframe.style.display = 'block';
-        this.iframe.addEventListener(
-          'load',
-          () => {
-            if (generation !== this._loadGeneration) return;
-            clearTimeout(safetyTimeout);
-            this._delayedIframeLoaded(generation);
-          },
-          { once: true }
-        );
-        this.iframe.addEventListener(
-          'error',
-          () => {
-            if (generation !== this._loadGeneration) return;
-            const errorMsg = `Failed to load virus iframe: ${name}`;
-            console.error(errorMsg);
-            Sentry.captureMessage(errorMsg, 'error');
-            clearTimeout(safetyTimeout);
-            this._delayedIframeLoaded(generation);
-          },
-          { once: true }
+        this._attachIframeListeners(
+          this.iframe,
+          generation,
+          `virus iframe: ${name}`
         );
       }
     } catch (error) {
@@ -290,57 +263,81 @@ class VirusLoader {
       Sentry.captureException(error);
       this.iframe.src = `/viruses/${playlist.viruses[0]}/`;
       this.iframe.style.display = 'block';
-      this.iframe.addEventListener(
-        'load',
-        () => {
-          if (generation !== this._loadGeneration) return;
-          clearTimeout(safetyTimeout);
-          this._delayedIframeLoaded(generation);
-        },
-        { once: true }
-      );
-      this.iframe.addEventListener(
-        'error',
-        () => {
-          if (generation !== this._loadGeneration) return;
-          const errorMsg = `Failed to load fallback virus iframe: ${playlist.viruses[0]}`;
-          console.error(errorMsg);
-          Sentry.captureMessage(errorMsg, 'error');
-          clearTimeout(safetyTimeout);
-          this._delayedIframeLoaded(generation);
-        },
-        { once: true }
+      this._attachIframeListeners(
+        this.iframe,
+        generation,
+        `fallback virus iframe: ${playlist.viruses[0]}`
       );
     }
   }
 
-  _delayedIframeLoaded(generation: number) {
+  private _attachIframeListeners(
+    frame: HTMLIFrameElement,
+    generation: number,
+    errorLabel: string
+  ): void {
+    frame.addEventListener(
+      'load',
+      () => {
+        if (generation !== this._loadGeneration) return;
+        if (this._safetyTimeout !== null) {
+          clearTimeout(this._safetyTimeout);
+          this._safetyTimeout = null;
+        }
+        this._delayedIframeLoaded(generation);
+      },
+      { once: true }
+    );
+    frame.addEventListener(
+      'error',
+      () => {
+        if (generation !== this._loadGeneration) return;
+        const errorMsg = `Failed to load ${errorLabel}`;
+        console.error(errorMsg);
+        Sentry.captureMessage(errorMsg, 'error');
+        if (this._safetyTimeout !== null) {
+          clearTimeout(this._safetyTimeout);
+          this._safetyTimeout = null;
+        }
+        this._delayedIframeLoaded(generation);
+      },
+      { once: true }
+    );
+  }
+
+  private _delayedIframeLoaded(generation: number) {
+    if (generation !== this._loadGeneration) return;
+
     const minDuration = 500;
     const elapsed = Date.now() - this.loadingAnimStartTime;
     if (elapsed >= minDuration) {
-      if (generation !== this._loadGeneration) return;
-      this.iframeLoaded();
+      this._iframeLoaded();
     } else {
       this._pendingRevealTimeout = setTimeout(() => {
         this._pendingRevealTimeout = null;
         if (generation !== this._loadGeneration) return;
-        this.iframeLoaded();
+        this._iframeLoaded();
       }, minDuration - elapsed);
     }
   }
 
-  iframeLoaded() {
+  private _stopLoadingAnim(): void {
     try {
-      try {
-        this.loadingAnim.stop();
-      } catch (error) {
-        console.error('Failed to stop loading animation:', error);
-        Sentry.captureException(error);
-      }
-      document.querySelectorAll('.tv-static-canvas').forEach(el => {
-        (el as HTMLElement).style.pointerEvents = 'none';
-        el.parentNode?.removeChild(el);
-      });
+      this.loadingAnim.stop();
+    } catch (error) {
+      console.error('Failed to stop loading animation:', error);
+      Sentry.captureException(error);
+      this.loadingAnimEl.style.display = 'none';
+    }
+    document.querySelectorAll('.tv-static-canvas').forEach(el => {
+      (el as HTMLElement).style.pointerEvents = 'none';
+      el.parentNode?.removeChild(el);
+    });
+  }
+
+  private _iframeLoaded() {
+    try {
+      this._stopLoadingAnim();
 
       if (!playlist.isMixedVirus(playlist.current())) {
         this.showSourceCodeLink();
@@ -351,7 +348,9 @@ class VirusLoader {
       console.error('Error in iframeLoaded:', error);
       Sentry.captureException(error);
     } finally {
-      this.iframe.style.visibility = 'visible';
+      if (this.iframe.style.display !== 'none') {
+        this.iframe.style.visibility = 'visible';
+      }
       document.querySelectorAll('.mixed-virus-container iframe').forEach(el => {
         (el as HTMLElement).style.visibility = 'visible';
       });

--- a/main.ts
+++ b/main.ts
@@ -32,12 +32,18 @@ if (import.meta.env.PROD) {
     profilesSampleRate: 1.0,
   });
 
-  if (window.__iconFontFailed) {
-    Sentry.captureMessage(
-      'Material Symbols icon font failed to load',
-      'warning'
-    );
-  }
+  // Defer the check: the icon font preload script in index.html may set
+  // __iconFontFailed after this module initializes (e.g. on timeout or
+  // fonts.load() rejection). Checking on 'load' guarantees the font script
+  // has resolved.
+  window.addEventListener('load', () => {
+    if (window.__iconFontFailed) {
+      Sentry.captureMessage(
+        'Material Symbols icon font failed to load',
+        'warning'
+      );
+    }
+  });
 }
 
 console.log(
@@ -241,12 +247,13 @@ class VirusLoader {
         } else {
           console.error('Mix not found for ID:', name);
           Sentry.captureMessage(`Mix not found for ID: ${name}`, 'error');
-          this.iframe.src = `/viruses/${playlist.viruses[0]}/`;
+          const fallbackVirus = playlist.viruses[0] ?? 'random-shapes';
+          this.iframe.src = `/viruses/${fallbackVirus}/`;
           this.iframe.style.display = 'block';
           this._attachIframeListeners(
             this.iframe,
             generation,
-            `fallback virus iframe (${playlist.viruses[0]}) after mix not found: ${name}`
+            `fallback virus iframe (${fallbackVirus}) after mix not found: ${name}`
           );
         }
       } else {
@@ -261,12 +268,13 @@ class VirusLoader {
     } catch (error) {
       console.error('Error loading virus:', error);
       Sentry.captureException(error);
-      this.iframe.src = `/viruses/${playlist.viruses[0]}/`;
+      const fallbackVirus = playlist.viruses[0] ?? 'random-shapes';
+      this.iframe.src = `/viruses/${fallbackVirus}/`;
       this.iframe.style.display = 'block';
       this._attachIframeListeners(
         this.iframe,
         generation,
-        `fallback virus iframe: ${playlist.viruses[0]}`
+        `fallback virus iframe: ${fallbackVirus}`
       );
     }
   }
@@ -290,10 +298,10 @@ class VirusLoader {
     );
     frame.addEventListener(
       'error',
-      () => {
+      (event: Event) => {
         if (generation !== this._loadGeneration) return;
         const errorMsg = `Failed to load ${errorLabel}`;
-        console.error(errorMsg);
+        console.error(errorMsg, event);
         Sentry.captureMessage(errorMsg, 'error');
         if (this._safetyTimeout !== null) {
           clearTimeout(this._safetyTimeout);
@@ -327,7 +335,7 @@ class VirusLoader {
     } catch (error) {
       console.error('Failed to stop loading animation:', error);
       Sentry.captureException(error);
-      this.loadingAnimEl.style.display = 'none';
+      if (this.loadingAnimEl) this.loadingAnimEl.style.display = 'none';
     }
     document.querySelectorAll('.tv-static-canvas').forEach(el => {
       (el as HTMLElement).style.pointerEvents = 'none';

--- a/main.ts
+++ b/main.ts
@@ -189,6 +189,7 @@ class VirusLoader {
           mixContainer.style.zIndex = '1';
 
           const mixFrame = createStyledIframe();
+          mixFrame.style.visibility = 'hidden';
           mixFrame.src = `/viruses/lab/?primary=${mix.primary}&secondary=${mix.secondary}&ratio=${mix.mixRatio}`;
 
           mixFrame.addEventListener('load', () => {
@@ -211,6 +212,7 @@ class VirusLoader {
           console.error('Mix not found for ID:', name);
           this.iframe.src = `/viruses/${playlist.viruses[0]}/`;
           this.iframe.style.display = 'block';
+          this.iframe.style.visibility = 'hidden';
           this.iframe.addEventListener(
             'load',
             () => {
@@ -223,6 +225,7 @@ class VirusLoader {
       } else {
         this.iframe.src = `/viruses/${name}/`;
         this.iframe.style.display = 'block';
+        this.iframe.style.visibility = 'hidden';
         this.iframe.addEventListener(
           'load',
           () => {
@@ -237,6 +240,7 @@ class VirusLoader {
       Sentry.captureException(error);
       this.iframe.src = `/viruses/${playlist.viruses[0]}/`;
       this.iframe.style.display = 'block';
+      this.iframe.style.visibility = 'hidden';
       this.iframe.addEventListener(
         'load',
         () => {
@@ -264,6 +268,13 @@ class VirusLoader {
       (el as HTMLElement).style.pointerEvents = 'none';
       el.parentNode?.removeChild(el);
     });
+
+    // Reveal iframes now that loading is complete
+    this.iframe.style.visibility = 'visible';
+    document.querySelectorAll('.mixed-virus-container iframe').forEach(el => {
+      (el as HTMLElement).style.visibility = 'visible';
+    });
+
     if (!playlist.isMixedVirus(playlist.current())) {
       this.showSourceCodeLink();
     }

--- a/main.ts
+++ b/main.ts
@@ -210,6 +210,7 @@ class VirusLoader {
 
     this._safetyTimeout = setTimeout(() => {
       if (generation !== this._loadGeneration) return;
+      this._safetyTimeout = null;
       const msg = `Safety timeout: forcing loading animation to stop for virus: ${name}`;
       console.warn(msg);
       Sentry.captureMessage(msg, 'warning');

--- a/main.ts
+++ b/main.ts
@@ -163,7 +163,9 @@ class VirusLoader {
     this.removeMixContainer();
 
     const safetyTimeout = setTimeout(() => {
-      console.warn('Safety timeout: forcing loading animation to stop');
+      const msg = `Safety timeout: forcing loading animation to stop for virus: ${name}`;
+      console.warn(msg);
+      Sentry.captureMessage(msg, 'warning');
       this._delayedIframeLoaded();
     }, 5000);
 
@@ -272,31 +274,34 @@ class VirusLoader {
 
   iframeLoaded() {
     try {
-      this.loadingAnim.stop();
+      try {
+        this.loadingAnim.stop();
+      } catch (error) {
+        console.error('Failed to stop loading animation:', error);
+        Sentry.captureException(error);
+      }
+      document.querySelectorAll('.tv-static-canvas').forEach(el => {
+        (el as HTMLElement).style.pointerEvents = 'none';
+        el.parentNode?.removeChild(el);
+      });
+
+      if (!playlist.isMixedVirus(playlist.current())) {
+        this.showSourceCodeLink();
+      }
+      if (this.sourceCodeLink)
+        this.sourceCodeLink.href = this.sourceCodeUrl(playlist.current());
     } catch (error) {
-      console.error('Failed to stop loading animation:', error);
+      console.error('Error in iframeLoaded:', error);
       Sentry.captureException(error);
+    } finally {
+      this.iframe.style.visibility = 'visible';
+      document.querySelectorAll('.mixed-virus-container iframe').forEach(el => {
+        (el as HTMLElement).style.visibility = 'visible';
+      });
+      this.loadingRing.classList.remove('loading');
+      const reloadBtn = document.getElementById('reload');
+      if (reloadBtn) reloadBtn.classList.remove('spinning');
     }
-    document.querySelectorAll('.tv-static-canvas').forEach(el => {
-      (el as HTMLElement).style.pointerEvents = 'none';
-      el.parentNode?.removeChild(el);
-    });
-
-    // Reveal iframes now that loading is complete
-    this.iframe.style.visibility = 'visible';
-    document.querySelectorAll('.mixed-virus-container iframe').forEach(el => {
-      (el as HTMLElement).style.visibility = 'visible';
-    });
-
-    if (!playlist.isMixedVirus(playlist.current())) {
-      this.showSourceCodeLink();
-    }
-    if (this.sourceCodeLink)
-      this.sourceCodeLink.href = this.sourceCodeUrl(playlist.current());
-    this.loadingRing.classList.remove('loading');
-
-    const reloadBtn = document.getElementById('reload');
-    if (reloadBtn) reloadBtn.classList.remove('spinning');
   }
 
   sourceCodeUrl(virus: string) {

--- a/main.ts
+++ b/main.ts
@@ -83,6 +83,7 @@ class VirusLoader {
   virusLab: VirusLab | null = null;
   isNavigating = false;
   private _loadGeneration = 0;
+  private _pendingRevealTimeout: ReturnType<typeof setTimeout> | null = null;
 
   constructor() {
     this.iframe = document.getElementById('container') as HTMLIFrameElement;
@@ -138,6 +139,12 @@ class VirusLoader {
 
   loadVirus(name: string) {
     const generation = ++this._loadGeneration;
+
+    if (this._pendingRevealTimeout !== null) {
+      clearTimeout(this._pendingRevealTimeout);
+      this._pendingRevealTimeout = null;
+    }
+
     virusHasKeyboardControl = false;
 
     // Randomly choose the loading animation for each load
@@ -169,7 +176,7 @@ class VirusLoader {
       const msg = `Safety timeout: forcing loading animation to stop for virus: ${name}`;
       console.warn(msg);
       Sentry.captureMessage(msg, 'warning');
-      this._delayedIframeLoaded();
+      this._delayedIframeLoaded(generation);
     }, 5000);
 
     try {
@@ -203,7 +210,7 @@ class VirusLoader {
             () => {
               if (generation !== this._loadGeneration) return;
               clearTimeout(safetyTimeout);
-              this._delayedIframeLoaded();
+              this._delayedIframeLoaded(generation);
             },
             { once: true }
           );
@@ -216,7 +223,7 @@ class VirusLoader {
               console.error(errorMsg);
               Sentry.captureMessage(errorMsg, 'error');
               clearTimeout(safetyTimeout);
-              this._delayedIframeLoaded();
+              this._delayedIframeLoaded(generation);
             },
             { once: true }
           );
@@ -236,7 +243,7 @@ class VirusLoader {
             () => {
               if (generation !== this._loadGeneration) return;
               clearTimeout(safetyTimeout);
-              this._delayedIframeLoaded();
+              this._delayedIframeLoaded(generation);
             },
             { once: true }
           );
@@ -248,7 +255,7 @@ class VirusLoader {
               console.error(errorMsg);
               Sentry.captureMessage(errorMsg, 'error');
               clearTimeout(safetyTimeout);
-              this._delayedIframeLoaded();
+              this._delayedIframeLoaded(generation);
             },
             { once: true }
           );
@@ -261,7 +268,7 @@ class VirusLoader {
           () => {
             if (generation !== this._loadGeneration) return;
             clearTimeout(safetyTimeout);
-            this._delayedIframeLoaded();
+            this._delayedIframeLoaded(generation);
           },
           { once: true }
         );
@@ -273,7 +280,7 @@ class VirusLoader {
             console.error(errorMsg);
             Sentry.captureMessage(errorMsg, 'error');
             clearTimeout(safetyTimeout);
-            this._delayedIframeLoaded();
+            this._delayedIframeLoaded(generation);
           },
           { once: true }
         );
@@ -288,7 +295,7 @@ class VirusLoader {
         () => {
           if (generation !== this._loadGeneration) return;
           clearTimeout(safetyTimeout);
-          this._delayedIframeLoaded();
+          this._delayedIframeLoaded(generation);
         },
         { once: true }
       );
@@ -300,20 +307,25 @@ class VirusLoader {
           console.error(errorMsg);
           Sentry.captureMessage(errorMsg, 'error');
           clearTimeout(safetyTimeout);
-          this._delayedIframeLoaded();
+          this._delayedIframeLoaded(generation);
         },
         { once: true }
       );
     }
   }
 
-  _delayedIframeLoaded() {
+  _delayedIframeLoaded(generation: number) {
     const minDuration = 500;
     const elapsed = Date.now() - this.loadingAnimStartTime;
     if (elapsed >= minDuration) {
+      if (generation !== this._loadGeneration) return;
       this.iframeLoaded();
     } else {
-      setTimeout(() => this.iframeLoaded(), minDuration - elapsed);
+      this._pendingRevealTimeout = setTimeout(() => {
+        this._pendingRevealTimeout = null;
+        if (generation !== this._loadGeneration) return;
+        this.iframeLoaded();
+      }, minDuration - elapsed);
     }
   }
 

--- a/main.ts
+++ b/main.ts
@@ -32,18 +32,27 @@ if (import.meta.env.PROD) {
     profilesSampleRate: 1.0,
   });
 
-  // Defer the check: the icon font preload script in index.html may set
-  // __iconFontFailed after this module initializes (e.g. on timeout or
-  // fonts.load() rejection). Checking on 'load' guarantees the font script
-  // has resolved.
-  window.addEventListener('load', () => {
-    if (window.__iconFontFailed) {
-      Sentry.captureMessage(
-        'Material Symbols icon font failed to load',
-        'warning'
-      );
-    }
-  });
+  // Report icon font failures to Sentry. The inline script in index.html
+  // sets __iconFontFailed and dispatches 'icon-font-failed' on failure.
+  // Hybrid check: the flag handles failures before this listener registers;
+  // the event handles failures that occur later (e.g. 3s timeout).
+  if (window.__iconFontFailed) {
+    Sentry.captureMessage(
+      'Material Symbols icon font failed to load',
+      'warning'
+    );
+  } else {
+    window.addEventListener(
+      'icon-font-failed',
+      () => {
+        Sentry.captureMessage(
+          'Material Symbols icon font failed to load',
+          'warning'
+        );
+      },
+      { once: true }
+    );
+  }
 }
 
 console.log(

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -23,7 +23,7 @@
   width: 100vw;
   height: 100vh;
   position: absolute;
-  z-index: 2;
+  z-index: var(--z-overlay);
   transition: all 0.1s linear;
 }
 


### PR DESCRIPTION
## Summary
- Hide iframes (`visibility: hidden`) during loading and reveal them only in `iframeLoaded()`, preventing unstyled content from flashing beneath the loading overlay
- Bump `#loading-anim` z-index from `2` to `var(--z-overlay)` (100) so the Flash loading animation reliably covers the iframe
- Add `&display=swap` to Material Symbols font URL and use `document.fonts.load()` with critical CSS to eliminate icon FOIT on slow connections

## Test plan
- [ ] `yarn build` passes
- [ ] `yarn lint` passes
- [ ] `yarn test` passes (108 tests)
- [ ] Manual: virus transitions show no content flash before loading animation finishes
- [ ] Manual: Flash (colored) loading animation fully covers iframe during transitions
- [ ] Manual: Material Symbols icons render without blank-box flash
- [ ] Manual: virus lab open/close works correctly
- [ ] Manual: skip next/previous works correctly