### PR TITLE
Deduplicate shared types, extract helpers, and clean up dead code

### DIFF
--- a/components/Playlist.ts
+++ b/components/Playlist.ts
@@ -1,12 +1,6 @@
+import { VirusMix } from '../types/VirusMix';
 import { shuffle } from '../utils/misc';
-
-interface VirusMix {
-  primary: string;
-  secondary: string;
-  mixRatio: number;
-  id?: number;
-  name?: string;
-}
+import { loadSavedMixes as loadSavedMixesFromStorage } from '../utils/savedMixes';
 
 export default class Playlist {
   viruses = [
@@ -41,17 +35,10 @@ export default class Playlist {
 
   constructor() {
     this.loadSavedMixes();
-    this.generatePlaylist();
   }
 
   loadSavedMixes() {
-    const savedMixesStr = localStorage.getItem('savedVirusMixes');
-    try {
-      this.savedMixes = JSON.parse(savedMixesStr || '[]') as VirusMix[];
-    } catch (e) {
-      console.error('Error parsing saved mixes:', e);
-      this.savedMixes = [];
-    }
+    this.savedMixes = loadSavedMixesFromStorage();
     // Regenerate playlist when saved mixes change
     this.generatePlaylist();
   }

--- a/components/VirusLab.ts
+++ b/components/VirusLab.ts
@@ -1,15 +1,12 @@
+import { VirusMix } from '../types/VirusMix';
 import { createStyledIframe } from '../utils/iframe';
 import { formatVirusName } from '../utils/misc';
+import {
+  loadSavedMixes as loadSavedMixesFromStorage,
+  saveMixes,
+} from '../utils/savedMixes';
 import Playlist from './Playlist';
 import controlsTemplate from './templates/virus-lab-controls.hbs';
-
-interface VirusMix {
-  primary: string;
-  secondary: string;
-  mixRatio: number;
-  id?: number;
-  name?: string;
-}
 
 export default class VirusLab {
   private container: HTMLElement;
@@ -92,19 +89,8 @@ export default class VirusLab {
     this.container.innerHTML = '';
   }
 
-  private loadSavedMixesFromStorage(): VirusMix[] {
-    try {
-      return JSON.parse(
-        localStorage.getItem('savedVirusMixes') || '[]'
-      ) as VirusMix[];
-    } catch (error) {
-      console.error('Failed to load saved virus mixes:', error);
-      return [];
-    }
-  }
-
   private loadSavedMixes() {
-    this.savedMixes = this.loadSavedMixesFromStorage();
+    this.savedMixes = loadSavedMixesFromStorage();
   }
 
   private initializeUI() {
@@ -203,7 +189,7 @@ export default class VirusLab {
   }
 
   private saveMix() {
-    const savedMixes = this.loadSavedMixesFromStorage();
+    const savedMixes = loadSavedMixesFromStorage();
 
     // Check for duplicates
     const isDuplicate = savedMixes.some(
@@ -232,7 +218,14 @@ export default class VirusLab {
     };
 
     savedMixes.push(newMix);
-    localStorage.setItem('savedVirusMixes', JSON.stringify(savedMixes));
+    if (!saveMixes(savedMixes)) {
+      const message = document.createElement('div');
+      message.className = 'save-message error';
+      message.textContent = 'Failed to save mix. Storage may be full.';
+      this.container.appendChild(message);
+      setTimeout(() => message.remove(), 2000);
+      return;
+    }
     this.savedMixes = savedMixes;
     this.updateSavedMixesList();
     this.playlist.loadSavedMixes();
@@ -302,7 +295,14 @@ export default class VirusLab {
 
   private deleteMix(mixId: number) {
     const savedMixes = this.savedMixes.filter(mix => mix.id !== mixId);
-    localStorage.setItem('savedVirusMixes', JSON.stringify(savedMixes));
+    if (!saveMixes(savedMixes)) {
+      const message = document.createElement('div');
+      message.className = 'save-message error';
+      message.textContent = 'Failed to delete mix.';
+      this.container.appendChild(message);
+      setTimeout(() => message.remove(), 2000);
+      return;
+    }
     this.savedMixes = savedMixes;
     this.updateSavedMixesList();
     this.playlist.loadSavedMixes();

--- a/components/VirusThumbnailOverlay.ts
+++ b/components/VirusThumbnailOverlay.ts
@@ -1,3 +1,4 @@
+import { VirusMix } from '../types/VirusMix';
 import { formatVirusName, isMobile } from '../utils/misc';
 import { safeGtag } from '../utils/gtag';
 import Playlist from './Playlist';
@@ -5,6 +6,71 @@ import Playlist from './Playlist';
 interface VirusLoader {
   virusLab: unknown;
   toggleLab(): void;
+}
+
+function formatMixEntry(mix: VirusMix, type: string, prefix: string) {
+  const mixRatioPercent = Math.round(mix.mixRatio * 100);
+  return {
+    value: `${prefix}:${type === 'premixed' ? mix.name : mix.id}`,
+    label: `${formatVirusName(mix.primary)} / ${formatVirusName(mix.secondary)} (${mixRatioPercent}%)`,
+    type,
+    mix: { ...mix, mixRatioPercent },
+  };
+}
+
+function renderMixSection(
+  title: string,
+  cssClass: string,
+  typeLabel: string,
+  items: ReturnType<typeof formatMixEntry>[]
+) {
+  if (items.length === 0) return '';
+  return `
+        <div class="virus-section ${cssClass}">
+          <h3 class="virus-section-title">${title}</h3>
+          <div class="virus-thumbnail-grid ${isMobile() ? 'mobile' : ''}">
+            ${items
+              .map(
+                virus => `
+              <div class="virus-thumbnail-item custom-virus" data-virus="${virus.value}" tabindex="0" role="button" aria-label="Select ${virus.label} ${typeLabel} virus">
+                <div class="virus-thumbnail-preview custom-preview">
+                  <div class="custom-virus-display">
+                    <div class="custom-virus-info">
+                      <div class="custom-virus-components">
+                        <span class="primary-virus">${virus.mix.primary}</span>
+                        <span class="mix-symbol">\u26A1</span>
+                        <span class="secondary-virus">${virus.mix.secondary}</span>
+                      </div>
+                      <div class="mix-ratio">${virus.mix.mixRatioPercent}%</div>
+                    </div>
+                  </div>
+                  <div class="virus-thumbnail-overlay-hover">
+                    <span class="play-icon">\u25B6</span>
+                  </div>
+                </div>
+                <div class="virus-label custom-label">${virus.label}</div>
+              </div>
+            `
+              )
+              .join('')}
+          </div>
+        </div>
+        `;
+}
+
+function trackVirusSelect(label: string, virus: string) {
+  safeGtag('event', 'virus_select', {
+    event_category: 'engagement',
+    event_label: label,
+    animation_name: virus,
+  });
+}
+
+function trackOverlayClose(label: string) {
+  safeGtag('event', 'virus_overlay_close', {
+    event_category: 'engagement',
+    event_label: label,
+  });
 }
 
 export function showVirusThumbnailOverlay({
@@ -35,30 +101,14 @@ export function showVirusThumbnailOverlay({
   }));
 
   // Get premixed viruses (default mixes)
-  const premixedViruses = playlist.premixes.map(mix => ({
-    value: `premix:${mix.name}`,
-    label: `${formatVirusName(mix.primary)} / ${formatVirusName(
-      mix.secondary
-    )} (${Math.round(mix.mixRatio * 100)}%)`,
-    type: 'premixed',
-    mix: {
-      ...mix,
-      mixRatioPercent: Math.round(mix.mixRatio * 100),
-    },
-  }));
+  const premixedViruses = playlist.premixes.map(mix =>
+    formatMixEntry(mix, 'premixed', 'premix')
+  );
 
   // Get custom viruses (saved mixes)
-  const customViruses = playlist.savedMixes.map(mix => ({
-    value: `mixed:${mix.id}`,
-    label: `${formatVirusName(mix.primary)} / ${formatVirusName(
-      mix.secondary
-    )} (${Math.round(mix.mixRatio * 100)}%)`,
-    type: 'custom',
-    mix: {
-      ...mix,
-      mixRatioPercent: Math.round(mix.mixRatio * 100),
-    },
-  }));
+  const customViruses = playlist.savedMixes.map(mix =>
+    formatMixEntry(mix, 'custom', 'mixed')
+  );
 
   // Create overlay HTML directly
   const overlay = document.createElement('div');
@@ -118,77 +168,9 @@ export function showVirusThumbnailOverlay({
           </div>
         </div>
 
-        ${
-          premixedViruses.length > 0
-            ? `
-        <div class="virus-section premixed-viruses">
-          <h3 class="virus-section-title">Premixed</h3>
-          <div class="virus-thumbnail-grid ${isMobile() ? 'mobile' : ''}">
-            ${premixedViruses
-              .map(
-                virus => `
-              <div class="virus-thumbnail-item custom-virus" data-virus="${virus.value}" tabindex="0" role="button" aria-label="Select ${virus.label} premixed virus">
-                <div class="virus-thumbnail-preview custom-preview">
-                  <div class="custom-virus-display">
-                    <div class="custom-virus-info">
-                      <div class="custom-virus-components">
-                        <span class="primary-virus">${virus.mix.primary}</span>
-                        <span class="mix-symbol">⚡</span>
-                        <span class="secondary-virus">${virus.mix.secondary}</span>
-                      </div>
-                      <div class="mix-ratio">${virus.mix.mixRatioPercent}%</div>
-                    </div>
-                  </div>
-                  <div class="virus-thumbnail-overlay-hover">
-                    <span class="play-icon">▶</span>
-                  </div>
-                </div>
-                <div class="virus-label custom-label">${virus.label}</div>
-              </div>
-            `
-              )
-              .join('')}
-          </div>
-        </div>
-        `
-            : ''
-        }
+        ${renderMixSection('Premixed', 'premixed-viruses', 'premixed', premixedViruses)}
 
-        ${
-          customViruses.length > 0
-            ? `
-        <div class="virus-section custom-viruses">
-          <h3 class="virus-section-title">Mixes</h3>
-          <div class="virus-thumbnail-grid ${isMobile() ? 'mobile' : ''}">
-            ${customViruses
-              .map(
-                virus => `
-              <div class="virus-thumbnail-item custom-virus" data-virus="${virus.value}" tabindex="0" role="button" aria-label="Select ${virus.label} custom virus">
-                <div class="virus-thumbnail-preview custom-preview">
-                  <div class="custom-virus-display">
-                    <div class="custom-virus-info">
-                      <div class="custom-virus-components">
-                        <span class="primary-virus">${virus.mix.primary}</span>
-                        <span class="mix-symbol">⚡</span>
-                        <span class="secondary-virus">${virus.mix.secondary}</span>
-                      </div>
-                      <div class="mix-ratio">${virus.mix.mixRatioPercent}%</div>
-                    </div>
-                  </div>
-                  <div class="virus-thumbnail-overlay-hover">
-                    <span class="play-icon">▶</span>
-                  </div>
-                </div>
-                <div class="virus-label custom-label">${virus.label}</div>
-              </div>
-            `
-              )
-              .join('')}
-          </div>
-        </div>
-        `
-            : ''
-        }
+        ${renderMixSection('Mixes', 'custom-viruses', 'custom', customViruses)}
       </div>
     </div>
   `;
@@ -284,12 +266,7 @@ export function showVirusThumbnailOverlay({
         virusLoader.toggleLab();
       }
 
-      // Track touch selection
-      safeGtag('event', 'virus_select', {
-        event_category: 'engagement',
-        event_label: 'touch_select',
-        animation_name: virus,
-      });
+      trackVirusSelect('touch_select', virus);
 
       onSelect(virus);
     }
@@ -338,12 +315,7 @@ export function showVirusThumbnailOverlay({
             filteredItems[currentFocusIndex].getAttribute('data-virus')!;
           cleanup();
 
-          // Track keyboard Enter selection
-          safeGtag('event', 'virus_select', {
-            event_category: 'engagement',
-            event_label: 'keyboard_enter',
-            animation_name: virus,
-          });
+          trackVirusSelect('keyboard_enter', virus);
 
           onSelect(virus);
         }
@@ -351,11 +323,7 @@ export function showVirusThumbnailOverlay({
       case 'Escape':
         cleanup();
 
-        // Track Escape key close
-        safeGtag('event', 'virus_overlay_close', {
-          event_category: 'engagement',
-          event_label: 'escape_key',
-        });
+        trackOverlayClose('escape_key');
 
         onClose();
         break;
@@ -372,11 +340,7 @@ export function showVirusThumbnailOverlay({
     e.stopPropagation();
     cleanup();
 
-    // Track close button click
-    safeGtag('event', 'virus_overlay_close', {
-      event_category: 'engagement',
-      event_label: 'close_button',
-    });
+    trackOverlayClose('close_button');
 
     onClose();
   };
@@ -385,11 +349,7 @@ export function showVirusThumbnailOverlay({
     if (e.target === overlay) {
       cleanup();
 
-      // Track background click close
-      safeGtag('event', 'virus_overlay_close', {
-        event_category: 'engagement',
-        event_label: 'background_click',
-      });
+      trackOverlayClose('background_click');
 
       onClose();
     }
@@ -405,12 +365,7 @@ export function showVirusThumbnailOverlay({
       virusLoader.toggleLab();
     }
 
-    // Track virus selection
-    safeGtag('event', 'virus_select', {
-      event_category: 'engagement',
-      event_label: 'thumbnail_click',
-      animation_name: virus,
-    });
+    trackVirusSelect('thumbnail_click', virus);
 
     onSelect(virus);
   };
@@ -429,12 +384,7 @@ export function showVirusThumbnailOverlay({
         virusLoader.toggleLab();
       }
 
-      // Track keyboard virus selection
-      safeGtag('event', 'virus_select', {
-        event_category: 'engagement',
-        event_label: 'keyboard_select',
-        animation_name: virus,
-      });
+      trackVirusSelect('keyboard_select', virus);
 
       onSelect(virus);
     }

--- a/components/VirusThumbnailOverlay.ts
+++ b/components/VirusThumbnailOverlay.ts
@@ -1,4 +1,5 @@
 import { VirusMix } from '../types/VirusMix';
+import { escapeHtml } from '../utils/escapeHtml';
 import { formatVirusName, isMobile } from '../utils/misc';
 import { safeGtag } from '../utils/gtag';
 import Playlist from './Playlist';
@@ -10,11 +11,17 @@ interface VirusLoader {
 
 function formatMixEntry(mix: VirusMix, type: string, prefix: string) {
   const mixRatioPercent = Math.round(mix.mixRatio * 100);
+  const label = `${formatVirusName(mix.primary)} / ${formatVirusName(mix.secondary)} (${mixRatioPercent}%)`;
   return {
-    value: `${prefix}:${type === 'premixed' ? mix.name : mix.id}`,
-    label: `${formatVirusName(mix.primary)} / ${formatVirusName(mix.secondary)} (${mixRatioPercent}%)`,
+    value: escapeHtml(`${prefix}:${type === 'premixed' ? mix.name : mix.id}`),
+    label: escapeHtml(label),
     type,
-    mix: { ...mix, mixRatioPercent },
+    mix: {
+      ...mix,
+      primary: escapeHtml(mix.primary),
+      secondary: escapeHtml(mix.secondary),
+      mixRatioPercent,
+    },
   };
 }
 
@@ -100,15 +107,15 @@ export function showVirusThumbnailOverlay({
     type: 'builtin',
   }));
 
-  // Get premixed viruses (default mixes)
-  const premixedViruses = playlist.premixes.map(mix =>
-    formatMixEntry(mix, 'premixed', 'premix')
-  );
+  // Get premixed viruses (default mixes), filtering out any without a name
+  const premixedViruses = playlist.premixes
+    .filter(mix => mix.name)
+    .map(mix => formatMixEntry(mix, 'premixed', 'premix'));
 
-  // Get custom viruses (saved mixes)
-  const customViruses = playlist.savedMixes.map(mix =>
-    formatMixEntry(mix, 'custom', 'mixed')
-  );
+  // Get custom viruses (saved mixes), filtering out any without an id
+  const customViruses = playlist.savedMixes
+    .filter(mix => mix.id)
+    .map(mix => formatMixEntry(mix, 'custom', 'mixed'));
 
   // Create overlay HTML directly
   const overlay = document.createElement('div');

--- a/main.ts
+++ b/main.ts
@@ -153,16 +153,14 @@ class VirusLoader {
     createThumbnailButton(this, playlist);
   }
 
-  private showSourceCodeLink() {
-    this.sourceCodeLink?.classList.remove('hide');
+  private setSourceCodeLinkVisible(visible: boolean) {
+    if (visible) {
+      this.sourceCodeLink?.classList.remove('hide');
+    } else {
+      this.sourceCodeLink?.classList.add('hide');
+    }
     const sourceCodeEl = document.getElementById('source-code');
-    if (sourceCodeEl) sourceCodeEl.style.display = '';
-  }
-
-  private hideSourceCodeLink() {
-    this.sourceCodeLink?.classList.add('hide');
-    const sourceCodeEl = document.getElementById('source-code');
-    if (sourceCodeEl) sourceCodeEl.style.display = 'none';
+    if (sourceCodeEl) sourceCodeEl.style.display = visible ? '' : 'none';
   }
 
   private removeMixContainer() {
@@ -198,7 +196,7 @@ class VirusLoader {
     console.log('Loading virus:', name);
     this.loadingAnim.start();
     this.loadingAnimStartTime = Date.now();
-    this.hideSourceCodeLink();
+    this.setSourceCodeLinkVisible(false);
     this.loadingRing.classList.add('loading');
     this.iframe.style.visibility = 'hidden';
 
@@ -228,7 +226,7 @@ class VirusLoader {
         }
         if (mix) {
           this.iframe.style.display = 'none';
-          this.hideSourceCodeLink();
+          this.setSourceCodeLinkVisible(false);
 
           const mixContainer = document.createElement('div');
           mixContainer.className = 'mixed-virus-container';
@@ -358,7 +356,7 @@ class VirusLoader {
       this._stopLoadingAnim();
 
       if (!playlist.isMixedVirus(playlist.current())) {
-        this.showSourceCodeLink();
+        this.setSourceCodeLinkVisible(true);
       }
       if (this.sourceCodeLink)
         this.sourceCodeLink.href = this.sourceCodeUrl(playlist.current());

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@typescript-eslint/parser": "8.46.2",
     "@vitest/coverage-v8": "4.0.5",
     "@vitest/ui": "4.0.5",
-    "concurrently": "9.2.1",
     "dotenv": "17.2.3",
     "eslint": "9.38.0",
     "glob": "11.0.3",

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -1,6 +1,25 @@
 @use './animations.scss';
 @use './_virus-lab.scss';
 
+@mixin custom-scrollbar {
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: #000;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--color-primary);
+    border-radius: 0;
+
+    &:hover {
+      background: #fff;
+    }
+  }
+}
+
 :root {
   --color-primary: #00ffff;
   --color-primary-dark: #00cccc;
@@ -579,22 +598,7 @@ iframe[id*='secondary'] {
   width: 100%;
   box-sizing: border-box;
 
-  &::-webkit-scrollbar {
-    width: 6px;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: #000;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: var(--color-primary);
-    border-radius: 0;
-
-    &:hover {
-      background: #fff;
-    }
-  }
+  @include custom-scrollbar;
 
   &.mobile {
     grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
@@ -1061,23 +1065,7 @@ iframe[id*='secondary'] {
   overflow-x: hidden;
   scrollbar-width: thin;
   scrollbar-color: var(--color-primary) var(--color-bg);
-
-  &::-webkit-scrollbar {
-    width: 6px;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: #000;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: var(--color-primary);
-    border-radius: 0;
-
-    &:hover {
-      background: #fff;
-    }
-  }
+  @include custom-scrollbar;
 }
 
 .virus-section {

--- a/types/VirusMix.ts
+++ b/types/VirusMix.ts
@@ -1,0 +1,7 @@
+export interface VirusMix {
+  primary: string;
+  secondary: string;
+  mixRatio: number;
+  id?: number;
+  name?: string;
+}

--- a/ui/fullscreen.ts
+++ b/ui/fullscreen.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/browser';
 import { isMobile } from '../utils/misc';
 import { safeGtag } from '../utils/gtag';
 
-export const FULLSCREEN = {
+const FULLSCREEN = {
   isActive: (): boolean => {
     const doc = document as Document & {
       fullscreenElement?: Element;

--- a/ui/menu.ts
+++ b/ui/menu.ts
@@ -12,7 +12,7 @@ export function toggleInfo(): void {
   }
 }
 
-export function displayInfo(): void {
+function displayInfo(): void {
   document.querySelector('.modal.info-modal')?.classList.add('show');
   const infoBtn = document.getElementById('info-btn');
   if (infoBtn) infoBtn.innerText = 'close';

--- a/utils/__tests__/escapeHtml.test.ts
+++ b/utils/__tests__/escapeHtml.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { escapeHtml } from '../escapeHtml';
+
+describe('escapeHtml', () => {
+  it('escapes ampersands', () => {
+    expect(escapeHtml('a&b')).toBe('a&amp;b');
+  });
+
+  it('escapes less-than signs', () => {
+    expect(escapeHtml('<script>')).toBe('&lt;script&gt;');
+  });
+
+  it('escapes double quotes', () => {
+    expect(escapeHtml('a"b')).toBe('a&quot;b');
+  });
+
+  it('escapes single quotes', () => {
+    expect(escapeHtml("a'b")).toBe('a&#039;b');
+  });
+
+  it('escapes all special characters together', () => {
+    expect(escapeHtml(`<div class="x" data-val='a&b'>`)).toBe(
+      '&lt;div class=&quot;x&quot; data-val=&#039;a&amp;b&#039;&gt;'
+    );
+  });
+
+  it('returns the same string when no escaping is needed', () => {
+    expect(escapeHtml('hello world 123')).toBe('hello world 123');
+  });
+
+  it('handles empty string', () => {
+    expect(escapeHtml('')).toBe('');
+  });
+});

--- a/utils/__tests__/savedMixes.test.ts
+++ b/utils/__tests__/savedMixes.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { loadSavedMixes, saveMixes } from '../savedMixes';
+
+describe('savedMixes', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('loadSavedMixes', () => {
+    it('returns an empty array when no data is stored', () => {
+      expect(loadSavedMixes()).toEqual([]);
+    });
+
+    it('returns parsed mixes from localStorage', () => {
+      const mixes = [
+        { primary: 'sphere', secondary: 'uzumaki', mixRatio: 0.5, id: 123 },
+      ];
+      localStorage.setItem('savedVirusMixes', JSON.stringify(mixes));
+      expect(loadSavedMixes()).toEqual(mixes);
+    });
+
+    it('returns an empty array for invalid JSON', () => {
+      localStorage.setItem('savedVirusMixes', 'not valid json');
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+        /* suppress */
+      });
+      expect(loadSavedMixes()).toEqual([]);
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('returns an empty array for empty string', () => {
+      localStorage.setItem('savedVirusMixes', '');
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+        /* suppress */
+      });
+      expect(loadSavedMixes()).toEqual([]);
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('saveMixes', () => {
+    it('saves mixes to localStorage and returns true', () => {
+      const mixes = [
+        { primary: 'sphere', secondary: 'uzumaki', mixRatio: 0.5, id: 123 },
+      ];
+      expect(saveMixes(mixes)).toBe(true);
+      expect(localStorage.getItem('savedVirusMixes')).toBe(
+        JSON.stringify(mixes)
+      );
+    });
+
+    it('returns false when localStorage.setItem throws', () => {
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new DOMException('QuotaExceededError');
+      });
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+        /* suppress */
+      });
+
+      expect(saveMixes([])).toBe(false);
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+      vi.restoreAllMocks();
+    });
+
+    it('saves an empty array', () => {
+      expect(saveMixes([])).toBe(true);
+      expect(localStorage.getItem('savedVirusMixes')).toBe('[]');
+    });
+  });
+});

--- a/utils/escapeHtml.ts
+++ b/utils/escapeHtml.ts
@@ -1,0 +1,8 @@
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}

--- a/utils/misc.ts
+++ b/utils/misc.ts
@@ -94,20 +94,6 @@ export function stripTags(str: string) {
   return str.replace(/(<([^>]+)>)/gi, '');
 }
 
-// export async function checkResponse(response: Response) {
-//   const status = response.status;
-//   if (response.ok) {
-//     return response.json();
-//   } else {
-//     return response.json().then((response) => {
-//       throw {
-//         error: response.detail,
-//         status: status,
-//       };
-//     });
-//   }
-// }
-
 export function formatVirusName(name: string) {
   return name.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
 }

--- a/utils/savedMixes.ts
+++ b/utils/savedMixes.ts
@@ -1,0 +1,22 @@
+import { VirusMix } from '../types/VirusMix';
+
+const STORAGE_KEY = 'savedVirusMixes';
+
+export function loadSavedMixes(): VirusMix[] {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]') as VirusMix[];
+  } catch (error) {
+    console.error('Failed to load saved virus mixes:', error);
+    return [];
+  }
+}
+
+export function saveMixes(mixes: VirusMix[]): boolean {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(mixes));
+    return true;
+  } catch (error) {
+    console.error('Failed to save virus mixes:', error);
+    return false;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1044,7 +1044,7 @@ chai@^6.0.1:
   resolved "https://registry.yarnpkg.com/chai/-/chai-6.2.0.tgz#181bca6a219cddb99c3eeefb82483800ffa550ce"
   integrity sha512-aUTnJc/JipRzJrNADXVvpVqi6CO0dn3nx4EVPxijri+fj3LUUDyZQOgVeW54Ob3Y1Xh9Iz8f+CgaCl8v0mn9bA==
 
-chalk@4.1.2, chalk@^4.0.0:
+chalk@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1094,15 +1094,6 @@ cli-truncate@^4.0.0:
     slice-ansi "^5.0.0"
     string-width "^7.0.0"
 
-cliui@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
-  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
-  dependencies:
-    string-width "^4.2.0"
-    strip-ansi "^6.0.1"
-    wrap-ansi "^7.0.0"
-
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
@@ -1129,18 +1120,6 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
-
-concurrently@9.2.1:
-  version "9.2.1"
-  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-9.2.1.tgz#248ea21b95754947be2dad9c3e4b60f18ca4e44f"
-  integrity sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==
-  dependencies:
-    chalk "4.1.2"
-    rxjs "7.8.2"
-    shell-quote "1.8.3"
-    supports-color "8.1.1"
-    tree-kill "1.2.2"
-    yargs "17.7.2"
 
 cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
@@ -1281,11 +1260,6 @@ esbuild@^0.25.0:
     "@esbuild/win32-arm64" "0.25.9"
     "@esbuild/win32-ia32" "0.25.9"
     "@esbuild/win32-x64" "0.25.9"
-
-escalade@^3.1.1:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
-  integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
@@ -1505,11 +1479,6 @@ fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
-get-caller-file@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
-  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-east-asian-width@^1.0.0, get-east-asian-width@^1.3.1:
   version "1.4.0"
@@ -2177,11 +2146,6 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-require-directory@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
-  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
-
 require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
@@ -2246,13 +2210,6 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@7.8.2:
-  version "7.8.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
-  integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
-  dependencies:
-    tslib "^2.1.0"
-
 "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
@@ -2297,11 +2254,6 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
-
-shell-quote@1.8.3:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.3.tgz#55e40ef33cf5c689902353a3d8cd1a6725f08b4b"
-  integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
 
 siginfo@^2.0.0:
   version "2.0.0"
@@ -2372,7 +2324,7 @@ string-argv@^0.3.2:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2436,13 +2388,6 @@ strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
-
-supports-color@8.1.1:
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
-  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
-  dependencies:
-    has-flag "^4.0.0"
 
 supports-color@^7.1.0:
   version "7.2.0"
@@ -2522,20 +2467,10 @@ tr46@^6.0.0:
   dependencies:
     punycode "^2.3.1"
 
-tree-kill@1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
-  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
-
 ts-api-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.1.0.tgz#595f7094e46eed364c13fd23e75f9513d29baf91"
   integrity sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==
-
-tslib@^2.1.0:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
-  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -2696,15 +2631,6 @@ wordwrap@^1.0.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
 wrap-ansi@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
@@ -2738,33 +2664,10 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-y18n@^5.0.5:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
-  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
-
 yaml@^2.7.0:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.2.tgz#5694f25eca0ce9c3e7a9d9e00ce0ddabbd9e35c5"
   integrity sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==
-
-yargs-parser@^21.1.1:
-  version "21.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
-  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
-
-yargs@17.7.2:
-  version "17.7.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
-  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
-  dependencies:
-    cliui "^8.0.1"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.3"
-    y18n "^5.0.5"
-    yargs-parser "^21.1.1"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Summary
- Extract `VirusMix` interface into shared `types/VirusMix.ts` (was duplicated in Playlist.ts and VirusLab.ts)
- Extract localStorage persistence into `utils/savedMixes.ts` with graceful error handling for storage-full failures
- Extract helper functions in `VirusThumbnailOverlay.ts` to reduce duplicated inline HTML templates and gtag tracking calls
- Consolidate `showSourceCodeLink()`/`hideSourceCodeLink()` into `setSourceCodeLinkVisible(visible)` in main.ts
- Extract repeated SCSS scrollbar styles into a `@mixin custom-scrollbar`
- Reduce export scope of `FULLSCREEN` and `displayInfo` (no external consumers)
- Remove commented-out `checkResponse` function and unused `concurrently` dependency
- Fix redundant double `generatePlaylist()` call in Playlist constructor

## Test plan
- [x] All 108 existing tests pass
- [x] Lint is clean
- [ ] Manual smoke test: playlist cycles through viruses correctly
- [ ] Manual smoke test: virus lab save/delete mixes works
- [ ] Manual smoke test: thumbnail overlay displays premixed and custom mixes
- [ ] Manual smoke test: fullscreen toggle and menu info modal work