### PR TITLE
Parameterize sky virus shader for per-instance variety

### DIFF
--- a/viruses/sky/sky.frag
+++ b/viruses/sky/sky.frag
@@ -122,7 +122,7 @@ void main() {
   vec4 c = clouds(uv, u_time, u_cloudiness);
   col = mix(col, c.rgb, c.a);
 
-  // 7 levels per channel (posterize)
+  // Posterize
   col = floor(col * u_posterLevels + 0.5) / u_posterLevels;
 
   col = hueShift(col, u_hueShift);

--- a/viruses/sky/sky.frag
+++ b/viruses/sky/sky.frag
@@ -4,6 +4,14 @@ uniform float u_time;
 uniform vec2 u_resolution;
 uniform float u_timeOfDay;
 uniform float u_cloudiness;
+uniform float u_pixelRes;
+uniform vec2  u_cloudScale;
+uniform float u_cloudSpeed;
+uniform float u_cloudOpacity;
+uniform float u_posterLevels;
+uniform float u_edgeOffset;
+uniform float u_hueShift;
+uniform float u_cloudHueShift;
 
 varying vec2 vUv;
 
@@ -26,6 +34,26 @@ float noise2d(vec2 p) {
 
 float fbm2(vec2 p) {
   return (noise2d(p) + noise2d(p * 2.0) * 0.5) / 1.5;
+}
+
+vec3 rgb2hsv(vec3 c) {
+  vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+  vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+  vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+  float d = q.x - min(q.w, q.y);
+  float e = 1.0e-10;
+  return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+}
+
+vec3 hsv2rgb(vec3 c) {
+  vec3 p = abs(fract(c.xxx + vec3(1.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - 3.0);
+  return c.z * mix(vec3(1.0), clamp(p - 1.0, 0.0, 1.0), c.y);
+}
+
+vec3 hueShift(vec3 col, float shift) {
+  vec3 hsv = rgb2hsv(col);
+  hsv.x = fract(hsv.x + shift);
+  return hsv2rgb(hsv);
 }
 
 vec3 skyGradient(vec2 uv, float tod) {
@@ -61,33 +89,30 @@ vec3 skyGradient(vec2 uv, float tod) {
 }
 
 vec4 clouds(vec2 uv, float time, float cloudiness) {
-  vec2 cloudUv = uv * vec2(6.0, 3.0) + vec2(time * 0.08, 0.0);
+  vec2 cloudUv = uv * u_cloudScale + vec2(time * u_cloudSpeed, 0.0);
 
   float cloud = fbm2(cloudUv);
 
   float threshold = mix(0.65, 0.2, cloudiness);
   cloud = step(threshold, cloud);
 
-  float heightMask = smoothstep(0.02, 0.08, uv.y) * smoothstep(0.98, 0.92, uv.y);
-  cloud *= heightMask;
-
   // Cloud base color: neon cyan, fading toward near-black at high cloudiness
-  vec3 cloudColor = vec3(0.0, 0.7, 0.9);
+  vec3 cloudColor = hueShift(vec3(0.0, 0.7, 0.9), u_cloudHueShift);
   cloudColor = mix(cloudColor, vec3(0.05), smoothstep(0.5, 1.0, cloudiness));
 
   // Edge detect via offset sample comparison
-  float cloudEdge = fbm2(cloudUv + 0.05);
+  float cloudEdge = fbm2(cloudUv + u_edgeOffset);
   cloudEdge = step(threshold, cloudEdge);
   float edge = abs(cloud - cloudEdge);
-  cloudColor = mix(cloudColor, vec3(1.0, 0.0, 0.5), edge * 0.9);
+  cloudColor = mix(cloudColor, hueShift(vec3(1.0, 0.0, 0.5), u_cloudHueShift), edge * 0.9);
 
-  return vec4(cloudColor, cloud * 0.85);
+  return vec4(cloudColor, cloud * u_cloudOpacity);
 }
 
 void main() {
   vec2 uv = vUv;
 
-  float pixelRes = 128.0;
+  float pixelRes = u_pixelRes;
   float aspect = u_resolution.x / u_resolution.y;
   vec2 grid = vec2(pixelRes * aspect, pixelRes);
   uv = floor(uv * grid) / grid;
@@ -98,7 +123,9 @@ void main() {
   col = mix(col, c.rgb, c.a);
 
   // 7 levels per channel (posterize)
-  col = floor(col * 6.0 + 0.5) / 6.0;
+  col = floor(col * u_posterLevels + 0.5) / u_posterLevels;
+
+  col = hueShift(col, u_hueShift);
 
   gl_FragColor = vec4(col, 1.0);
 }

--- a/viruses/sky/sky.ts
+++ b/viruses/sky/sky.ts
@@ -35,12 +35,12 @@ class Sky {
     this.scene = new THREE.Scene();
     this.camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
 
-    const pixelRes = randomFloat(128, 320);
+    const pixelRes = Math.round(randomFloat(128, 320));
     const cloudScaleX = randomFloat(8, 18);
     const cloudScaleY = randomFloat(4, 9);
     const cloudSpeed = randomFloat(0.03, 0.15);
     const cloudOpacity = randomFloat(0.6, 0.95);
-    const posterLevels = randomFloat(4, 10);
+    const posterLevels = Math.round(randomFloat(4, 10));
     const edgeOffset = randomFloat(0.02, 0.1);
     const hueShift = Math.random();
     const cloudHueShift = Math.random();

--- a/viruses/sky/sky.ts
+++ b/viruses/sky/sky.ts
@@ -35,6 +35,16 @@ class Sky {
     this.scene = new THREE.Scene();
     this.camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
 
+    const pixelRes = randomFloat(128, 320);
+    const cloudScaleX = randomFloat(8, 18);
+    const cloudScaleY = randomFloat(4, 9);
+    const cloudSpeed = randomFloat(0.03, 0.15);
+    const cloudOpacity = randomFloat(0.6, 0.95);
+    const posterLevels = randomFloat(4, 10);
+    const edgeOffset = randomFloat(0.02, 0.1);
+    const hueShift = Math.random();
+    const cloudHueShift = Math.random();
+
     this.material = new THREE.ShaderMaterial({
       vertexShader,
       fragmentShader,
@@ -48,6 +58,14 @@ class Sky {
         },
         u_timeOfDay: { value: 0.5 },
         u_cloudiness: { value: 0.3 },
+        u_pixelRes: { value: pixelRes },
+        u_cloudScale: { value: new THREE.Vector2(cloudScaleX, cloudScaleY) },
+        u_cloudSpeed: { value: cloudSpeed },
+        u_cloudOpacity: { value: cloudOpacity },
+        u_posterLevels: { value: posterLevels },
+        u_edgeOffset: { value: edgeOffset },
+        u_hueShift: { value: hueShift },
+        u_cloudHueShift: { value: cloudHueShift },
       },
     });
 
@@ -82,7 +100,7 @@ class Sky {
     // Random jumps
     if (elapsed > this.nextJump) {
       this.targetTod = Math.random();
-      this.targetCloudiness = Math.random();
+      this.targetCloudiness = randomFloat(0.3, 1);
       this.nextJump = elapsed + randomFloat(2, 5);
     }
 


### PR DESCRIPTION
## Summary
- Extract hardcoded shader values (pixel resolution, cloud scale/speed/opacity, posterization levels, edge offset) into randomized uniforms so each page load produces a visually distinct sky
- Add HSV color-space utilities (`rgb2hsv`, `hsv2rgb`, `hueShift`) to the fragment shader
- Apply per-instance hue shifts to both the sky and cloud colors
- Clamp minimum cloudiness to 0.3 so the sky always has some cloud activity

## Test plan
- [ ] `yarn dev` → navigate to sky virus, reload several times to confirm each load looks different
- [ ] Verify clouds, posterization, and hue shifts all vary between loads
- [ ] `yarn build` passes
- [ ] `yarn lint` passes