### PR TITLE
Add tick-tock virus

### DIFF
--- a/components/Playlist.ts
+++ b/components/Playlist.ts
@@ -18,6 +18,7 @@ export default class Playlist {
     'void',
     'crane-game',
     'sky',
+    'tick-tock',
   ];
 
   premixes: VirusMix[] = [

--- a/viruses/tick-tock/index.html
+++ b/viruses/tick-tock/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, height=device-height, initial-scale = 1.0, maximum-scale = 1.0"
+    />
+    <link rel="shortcut icon" href="/favicon.png" />
+    <link
+      rel="stylesheet"
+      href="/css/reset.css"
+      type="text/css"
+      media="screen"
+    />
+  </head>
+  <body>
+    <div id="container"></div>
+    <script type="module" src="./tick-tock.ts"></script>
+  </body>
+</html>

--- a/viruses/tick-tock/tick-tock.scss
+++ b/viruses/tick-tock/tick-tock.scss
@@ -1,0 +1,23 @@
+@use '../../sass/animations.scss';
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: #000;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+#container {
+  position: fixed;
+  inset: 0;
+  background: #000;
+
+  canvas {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+}

--- a/viruses/tick-tock/tick-tock.ts
+++ b/viruses/tick-tock/tick-tock.ts
@@ -25,8 +25,8 @@ function resize() {
   cssH = container.clientHeight;
   canvas.style.width = `${String(cssW)}px`;
   canvas.style.height = `${String(cssH)}px`;
-  canvas.width = Math.floor(cssW * dpr);
-  canvas.height = Math.floor(cssH * dpr);
+  canvas.width = Math.round(cssW * dpr);
+  canvas.height = Math.round(cssH * dpr);
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 }
 
@@ -77,13 +77,16 @@ function drawClock(cx: number, cy: number, cell: number, angle: number) {
   ctx.stroke();
 
   const dot = cell >= 40 ? 2 : 1;
-  ctx.fillRect(cx - dot / 2, cy - dot / 2, dot, dot);
+  const dotX = Math.round(cx - dot / 2);
+  const dotY = Math.round(cy - dot / 2);
+  ctx.fillRect(dotX, dotY, dot, dot);
 }
 
 function frame(now: number) {
-  if (now - stageStart >= STAGE_MS) {
-    stageIdx = (stageIdx + 1) % sizes.length;
-    stageStart = now;
+  const elapsedStages = Math.floor((now - stageStart) / STAGE_MS);
+  if (elapsedStages > 0) {
+    stageIdx = (stageIdx + elapsedStages) % sizes.length;
+    stageStart += elapsedStages * STAGE_MS;
   }
 
   const cell = sizes[stageIdx];

--- a/viruses/tick-tock/tick-tock.ts
+++ b/viruses/tick-tock/tick-tock.ts
@@ -1,0 +1,117 @@
+import { isMobile } from '../../utils/misc';
+import './tick-tock.scss';
+
+const DESKTOP_SIZES = [160, 112, 80, 56, 40, 28, 20, 14, 10, 7, 5, 3];
+const MOBILE_SIZES = [96, 72, 52, 38, 28, 20, 14, 10, 7, 5, 3];
+const STAGE_MS = 1000;
+const TICK_PERIOD_MS = 2000;
+
+const sizes = isMobile() ? MOBILE_SIZES : DESKTOP_SIZES;
+
+const container = document.getElementById('container')!;
+const canvas = document.createElement('canvas');
+container.appendChild(canvas);
+const ctx = canvas.getContext('2d')!;
+
+let cssW = 0;
+let cssH = 0;
+let stageIdx = 0;
+let stageStart = performance.now();
+let rafHandle = 0;
+
+function resize() {
+  const dpr = window.devicePixelRatio || 1;
+  cssW = container.clientWidth;
+  cssH = container.clientHeight;
+  canvas.style.width = `${String(cssW)}px`;
+  canvas.style.height = `${String(cssH)}px`;
+  canvas.width = Math.floor(cssW * dpr);
+  canvas.height = Math.floor(cssH * dpr);
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+}
+
+function drawClock(cx: number, cy: number, cell: number, angle: number) {
+  const radius = cell * 0.42;
+
+  if (cell <= 4) {
+    ctx.fillRect(Math.floor(cx), Math.floor(cy), 1, 1);
+    return;
+  }
+
+  if (cell < 8) {
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(cx, cy);
+    ctx.lineTo(cx + Math.cos(angle) * radius, cy + Math.sin(angle) * radius);
+    ctx.stroke();
+    return;
+  }
+
+  if (cell < 14) {
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(cx, cy);
+    ctx.lineTo(
+      cx + Math.cos(angle) * radius * 0.85,
+      cy + Math.sin(angle) * radius * 0.85
+    );
+    ctx.stroke();
+    return;
+  }
+
+  ctx.lineWidth = Math.max(1, cell * 0.05);
+  ctx.beginPath();
+  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+  ctx.stroke();
+
+  ctx.lineWidth = Math.max(1, cell * 0.07);
+  ctx.beginPath();
+  ctx.moveTo(cx, cy);
+  ctx.lineTo(
+    cx + Math.cos(angle) * radius * 0.85,
+    cy + Math.sin(angle) * radius * 0.85
+  );
+  ctx.stroke();
+
+  const dot = cell >= 40 ? 2 : 1;
+  ctx.fillRect(cx - dot / 2, cy - dot / 2, dot, dot);
+}
+
+function frame(now: number) {
+  if (now - stageStart >= STAGE_MS) {
+    stageIdx = (stageIdx + 1) % sizes.length;
+    stageStart = now;
+  }
+
+  const cell = sizes[stageIdx];
+  const cols = Math.ceil(cssW / cell);
+  const rows = Math.ceil(cssH / cell);
+  const angle =
+    ((now % TICK_PERIOD_MS) / TICK_PERIOD_MS) * Math.PI * 2 - Math.PI / 2;
+
+  ctx.fillStyle = '#000';
+  ctx.fillRect(0, 0, cssW, cssH);
+  ctx.strokeStyle = '#fff';
+  ctx.fillStyle = '#fff';
+
+  const half = cell / 2;
+  for (let r = 0; r < rows; r++) {
+    const cy = r * cell + half;
+    for (let c = 0; c < cols; c++) {
+      drawClock(c * cell + half, cy, cell, angle);
+    }
+  }
+
+  rafHandle = requestAnimationFrame(frame);
+}
+
+window.addEventListener('resize', resize);
+window.addEventListener('pagehide', () => {
+  cancelAnimationFrame(rafHandle);
+});
+
+resize();
+rafHandle = requestAnimationFrame(frame);


### PR DESCRIPTION
## Summary
- New virus: a grid of identical analog clocks ticking in perfect lockstep
- Each cycle the grid densifies — cells shrink, clocks multiply — until the screen is a near-solid mass, then snaps back to sparse and begins again
- Canvas 2D rendering with size-threshold degradation (rim+hand → single line → single pixel) so peak density stays smooth

## Test plan
- [ ] `yarn dev` and open `/?virus=tick-tock` — watch one full cycle (~12s desktop / ~11s mobile): sparse → dense → snap → repeat
- [ ] All visible clocks share the same hand angle at every moment (no per-clock drift)
- [ ] Snap reset is a single-frame jump, not animated
- [ ] Resize mid-densification — column/row count adjusts immediately
- [ ] Mobile emulation: starts smaller, still bottoms out at ~3px cells
- [ ] No fuzzy clock rims on retina (DPR scaling)
- [ ] Reload `/` a few times and confirm `tick-tock` appears in the playlist rotation